### PR TITLE
deployment: fix name to knoxautopolicy

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.labels.app }}
+  name: knoxautopolicy
   labels:
     deployment: knoxautopolicy
 spec:


### PR DESCRIPTION
Fix error while deployment 

``` sh
error: error parsing https://raw.githubusercontent.com/accuknox/knoxAutoPolicy-deployment/main/k8s/deployment.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.labels.app":interface {}(nil)}
```